### PR TITLE
added image commit feature

### DIFF
--- a/context/apps/Dockerfile.real
+++ b/context/apps/Dockerfile.real
@@ -1,5 +1,13 @@
 FROM ras_base:ras_local AS builder
 
+RUN apt-get install lsb-release wget gnupg curl -y
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+RUN apt-get update
+RUN apt-get install -y ignition-fortress
+
+RUN pip install awsiotsdk
+
 RUN mkdir -p /ras_real_lab
 
 RUN apt update && apt install -y inetutils-ping

--- a/context/apps/Dockerfile.real
+++ b/context/apps/Dockerfile.real
@@ -14,6 +14,16 @@ RUN apt update && apt install -y inetutils-ping
 RUN apt install wget unzip -y
 RUN pip install xArm-Python-SDK
 
+USER ras
+RUN python3 -m pip install flask pyftpdlib paho-mqtt opencv-contrib-python==4.7.0.72 numpy==1.21.5
+USER root
+
+RUN apt install software-properties-common -y && \ 
+    apt-add-repository ppa:mosquitto-dev/mosquitto-ppa -y && \
+    apt-get update &&  apt install mosquitto -y
+
+RUN  apt install ros-humble-rclpy-message-converter -y 
+
 RUN echo "source /ras_real_lab/scripts/env.sh" >> /etc/bash.bashrc
 
 CMD ["sleep", "infinity"]

--- a/context/apps/Dockerfile.sim
+++ b/context/apps/Dockerfile.sim
@@ -19,7 +19,11 @@ USER ras
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     && . ~/.nvm/nvm.sh \
     && nvm install 20 -y
+RUN python3 -m pip install flask pyftpdlib paho-mqtt
 USER root
+RUN apt install software-properties-common -y && \ 
+    apt-add-repository ppa:mosquitto-dev/mosquitto-ppa -y && \
+    apt-get update &&  apt install mosquitto -y
 RUN touch ~/.tmux.conf && echo "set -g mouse on" >> ~/.tmux.conf
 
 RUN pip install openai


### PR DESCRIPTION
Added few futures for docker interface
1. moved application script into alias `ras_app` and  `ras_kill` to effectively kill and start app instances. Adds possibility of running multiple instances of docker terminals and restarting the app without having ghost instances.
2.  added feature of committing to docker image via `rdi sim dev -c` to enable developers to easily modify images for testing purposes as well as pushing to dockerhub.
3. added feature to start a terminator instance for developers to have ease in debugging.
4. restructured docker commands to have more granularity with docker options and instances.